### PR TITLE
SHA-245: Fix dist path

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
     types:
       - opened
       - closed
@@ -49,7 +50,7 @@ jobs:
           SENTRY_RELEASE: "shortcut-assistant@${{ env.VERSION }}"
 
       - name: Upload dist.zip as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: dist-zip
           path: dist/dist.zip

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - develop
     types:
       - opened
       - closed

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/download-artifact@v4.1.7
         with:
           name: dist-zip
-          path: dist
+          path: dist/dist.zip
 
       - name: Upload release asset
         uses: actions/github-script@v6

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/download-artifact@v4.1.7
         with:
           name: dist-zip
-          path: dist/dist.zip
+          path: dist
 
       - name: Upload release asset
         uses: actions/github-script@v6


### PR DESCRIPTION
## What's Changed
- Changed path of dist zip for downloading artifact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration for more precise artifact download path.
	- Clarified conditions for executing the release asset upload job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->