### PR TITLE
Add GitHub scripts for release management

### DIFF
--- a/.github/scripts/create-draft-release.js
+++ b/.github/scripts/create-draft-release.js
@@ -1,0 +1,43 @@
+/**
+ * Creates or updates a draft release based on the PR details
+ */
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  const pr = context.payload.pull_request;
+  const releaseTag = pr.title;
+  const releaseNotes = pr.body;
+  
+  const releases = await github.rest.repos.listReleases({
+    owner,
+    repo,
+  });
+  
+  let draftRelease = releases.data.find(release => release.tag_name === releaseTag && release.draft === true);
+  
+  if (!draftRelease) {
+    console.log(`Creating draft release`);
+    draftRelease = await github.rest.repos.createRelease({
+      owner,
+      repo,
+      tag_name: releaseTag,
+      name: releaseTag,
+      body: releaseNotes,
+      draft: true,
+    });
+    console.log(`Draft release created`);
+  } else {
+    console.log(`Updating existing draft release`);
+    draftRelease = await github.rest.repos.updateRelease({
+      owner,
+      repo,
+      release_id: draftRelease.id,
+      body: releaseNotes,
+      draft: true,
+    });
+    console.log(`Draft release updated`);
+  }
+  
+  console.log(`Draft release ID: ${draftRelease.id}`);
+  core.setOutput("upload_url", draftRelease.upload_url);
+  core.setOutput("release_id", draftRelease.id);
+}; 

--- a/.github/scripts/get-merged-pr-info.js
+++ b/.github/scripts/get-merged-pr-info.js
@@ -1,0 +1,39 @@
+/**
+ * Finds the most recently merged PR and returns its information
+ */
+module.exports = async ({ github, context, core }) => {
+  const { owner, repo } = context.repo;
+  
+  // Find the PR that triggered the workflow run
+  const pulls = await github.rest.pulls.list({
+    owner: owner,
+    repo: repo,
+    state: 'closed',
+    sort: 'updated',
+    direction: 'desc',
+    per_page: 10
+  });
+  
+  // Find the most recently merged PR
+  const mergedPR = pulls.data.find(pr => pr.merged_at !== null);
+  
+  if (!mergedPR) {
+    core.setFailed('No recently merged PR found');
+    return null;
+  }
+  
+  console.log(`Found merged PR: #${mergedPR.number}, title: ${mergedPR.title}`);
+  
+  const result = {
+    title: mergedPR.title,
+    body: mergedPR.body,
+    number: mergedPR.number
+  };
+  
+  // Set outputs
+  core.setOutput('pr_title', result.title);
+  core.setOutput('pr_body', result.body);
+  core.setOutput('pr_number', result.number);
+  
+  return result;
+}; 

--- a/.github/scripts/publish-release.js
+++ b/.github/scripts/publish-release.js
@@ -1,0 +1,22 @@
+/**
+ * Publishes a draft release by setting draft=false
+ */
+module.exports = async ({ github, context, core, releaseId }) => {
+  const { owner, repo } = context.repo;
+  
+  console.log(`Publishing release ${releaseId}`);
+  
+  try {
+    const release = await github.rest.repos.updateRelease({
+      owner,
+      repo,
+      release_id: releaseId,
+      draft: false
+    });
+    
+    console.log(`Release published: ${release.data.html_url}`);
+    return release.data;
+  } catch (error) {
+    core.setFailed(`Failed to publish release: ${error.message}`);
+  }
+}; 

--- a/.github/scripts/update-and-publish-release.js
+++ b/.github/scripts/update-and-publish-release.js
@@ -1,0 +1,38 @@
+/**
+ * Updates a release with the latest PR information and publishes it
+ */
+module.exports = async ({ github, context, core, releaseTag, releaseBody }) => {
+  const { owner, repo } = context.repo;
+  
+  try {
+    // Find existing release
+    const releases = await github.rest.repos.listReleases({
+      owner,
+      repo,
+    });
+    
+    const draftRelease = releases.data.find(release => release.tag_name === releaseTag && release.draft === true);
+    
+    if (!draftRelease) {
+      core.setFailed(`No draft release found with tag ${releaseTag}`);
+      return null;
+    }
+    
+    console.log(`Found draft release: ${draftRelease.id}`);
+    
+    // Update release with latest PR description
+    const updatedRelease = await github.rest.repos.updateRelease({
+      owner,
+      repo,
+      release_id: draftRelease.id,
+      body: releaseBody,
+      draft: false
+    });
+    
+    console.log(`Release published: ${updatedRelease.data.html_url}`);
+    return updatedRelease.data;
+  } catch (error) {
+    core.setFailed(`Failed to update or publish release: ${error.message}`);
+    return null;
+  }
+}; 

--- a/.github/scripts/upload-release-asset.js
+++ b/.github/scripts/upload-release-asset.js
@@ -1,0 +1,62 @@
+/**
+ * Uploads an asset to a GitHub release
+ * Handles checking for and deleting existing assets with the same name
+ */
+module.exports = async ({ github, context, core, releaseId }) => {
+  const fs = require('fs');
+  const { owner, repo } = context.repo;
+  
+  const assetPath = './dist/dist.zip';
+  const assetName = 'ChromeExtension.zip';
+  
+  console.log(`Uploading asset ${assetPath} to release ${releaseId}`);
+  
+  // Check if file exists
+  if (!fs.existsSync(assetPath)) {
+    core.setFailed(`Asset file not found: ${assetPath}`);
+    return;
+  }
+  
+  const data = fs.readFileSync(assetPath);
+  
+  // Delete existing asset if it exists
+  try {
+    const assets = await github.rest.repos.listReleaseAssets({
+      owner,
+      repo,
+      release_id: releaseId
+    });
+    
+    for (const asset of assets.data) {
+      if (asset.name === assetName) {
+        console.log(`Deleting existing asset ${asset.id}`);
+        await github.rest.repos.deleteReleaseAsset({
+          owner,
+          repo,
+          asset_id: asset.id
+        });
+      }
+    }
+  } catch (error) {
+    console.log(`Error checking for existing assets: ${error.message}`);
+  }
+  
+  // Upload new asset
+  try {
+    const result = await github.rest.repos.uploadReleaseAsset({
+      owner,
+      repo,
+      release_id: releaseId,
+      name: assetName,
+      data,
+      headers: {
+        'content-type': 'application/zip',
+        'content-length': fs.statSync(assetPath).size
+      }
+    });
+    
+    console.log(`Asset uploaded successfully: ${result.data.browser_download_url}`);
+  } catch (error) {
+    core.setFailed(`Failed to upload asset: ${error.message}`);
+  }
+}; 

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -9,9 +9,10 @@ on:
       - closed
       - synchronize
 
+# Define minimum required permissions
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write    # Needed for creating/updating releases and uploading assets
+  pull-requests: read # Only need to read PR information
 
 jobs:
   prepare-release-assets:
@@ -30,7 +31,7 @@ jobs:
           node-version: '21'
 
       - name: Install dependencies
-        run: cd src && yarn
+        run: yarn
 
       - name: Extract tag name
         id: extract_tag
@@ -48,8 +49,7 @@ jobs:
 
       - name: Build and zip the extension
         run: |
-          mkdir dist
-          cd src
+          mkdir -p dist
           yarn run build-css
           yarn run dist
         env:
@@ -69,36 +69,16 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
-            const releaseTag = pr.title;
-            const releaseNotes = pr.body;
-            const releases = await github.rest.repos.listReleases({
-              owner,
-              repo,
-            });
-            let draftRelease = releases.data.find(release => release.tag_name === releaseTag && release.draft === true);
-            if (!draftRelease) {
-            console.log(`Creating draft release`);
-              draftRelease = await github.rest.repos.createRelease({
-                owner,
-                repo,
-                tag_name: releaseTag,
-                name: releaseTag,
-                body: releaseNotes,
-                draft: true,
-              });
-              console.log(`Draft release created`);
-            }
-            console.log(draftRelease)
-            core.setOutput("upload_url", draftRelease.upload_url);
-            core.setOutput("release_id", draftRelease.id);
+            const createDraftRelease = require('./.github/scripts/create-draft-release.js');
+            return await createDraftRelease({ github, context, core });
 
   upload-release-asset:
     needs: prepare-release-assets
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Download dist.zip artifact
         uses: actions/download-artifact@v4.1.7
         with:
@@ -110,32 +90,31 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
-            const releases = await github.rest.repos.listReleases({
-              owner,
-              repo,
+            const uploadReleaseAsset = require('./.github/scripts/upload-release-asset.js');
+            await uploadReleaseAsset({ 
+              github, 
+              context, 
+              core, 
+              releaseId: ${{ needs.prepare-release-assets.outputs.release_id }} 
             });
-            const releaseTag = pr.title;
-            let draftRelease = releases.data.find(release => release.tag_name === releaseTag && release.draft === true);
-            const releaseId = draftRelease.id;
-            const assetPath = './dist/dist.zip';
-            const assetName = 'ChromeExtension.zip';
-            const assetContentType = 'application/zip'; 
-            const data = require('fs').readFileSync(assetPath);
-            console.log(`Uploading asset ${assetPath} to release ${releaseId}`);
-            console.log(`Release published: https://github.com/${owner}/${repo}/releases/tag/${releaseId}`);
-            release = await github.rest.repos.updateRelease({
-              owner,
-              repo,
-              release_id: releaseId,
-              draft: false,
+
+  publish-release:
+    needs: [prepare-release-assets, upload-release-asset]
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Publish release
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const publishRelease = require('./.github/scripts/publish-release.js');
+            await publishRelease({ 
+              github, 
+              context, 
+              core, 
+              releaseId: ${{ needs.prepare-release-assets.outputs.release_id }} 
             });
-            await github.rest.repos.uploadReleaseAsset({
-              owner,
-              repo,
-              release_id: releaseId,
-              name: assetName,
-              data,
-            });
-            console.log('Asset uploaded');

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -2,55 +2,50 @@ name: Publish Release
 
 on:
   workflow_run:
-    workflows: ["Prepare Release Assets"]
+    workflows: ["Release Version"]
     types:
       - completed
 
+# Define minimum required permissions
+permissions:
+  contents: write    # Needed for updating releases
+  actions: read      # Needed to download artifacts
+
 jobs:
-  upload-release-asset:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.pull_request.merged == true }}
+  publish-release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_branch != 'main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Download dist.zip artifact
-        uses: actions/download-artifact@v4.1.7
+      - name: Download workflow artifacts
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
           name: dist-zip
           path: dist
 
-      - name: Upload release asset
+      - name: Get PR information
+        id: pr_info
         uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
-            const releases = await github.rest.repos.listReleases({
-              owner,
-              repo,
+            const getMergedPrInfo = require('./.github/scripts/get-merged-pr-info.js');
+            return await getMergedPrInfo({ github, context, core });
+
+      - name: Update and publish release
+        if: steps.pr_info.outputs.pr_title
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const updateAndPublishRelease = require('./.github/scripts/update-and-publish-release.js');
+            await updateAndPublishRelease({ 
+              github, 
+              context, 
+              core, 
+              releaseTag: '${{ steps.pr_info.outputs.pr_title }}',
+              releaseBody: '${{ steps.pr_info.outputs.pr_body }}'
             });
-            const releaseTag = pr.title;
-            let draftRelease = releases.data.find(release => release.tag_name === releaseTag && release.draft === true);
-            const releaseId = draftRelease.id;
-            const assetPath = './dist/dist.zip';
-            const assetName = 'ChromeExtension.zip';
-            const assetContentType = 'application/zip'; 
-            const data = require('fs').readFileSync(assetPath);
-            console.log(`Uploading asset ${assetPath} to release ${releaseId}`);
-            console.log(`Release published: https://github.com/${owner}/${repo}/releases/tag/${releaseId}`);
-            release = await github.rest.repos.updateRelease({
-              owner,
-              repo,
-              release_id: releaseId,
-              draft: false,
-            });
-            await github.rest.repos.uploadReleaseAsset({
-              owner,
-              repo,
-              release_id: releaseId,
-              name: assetName,
-              data,
-            });
-            console.log('Asset uploaded');


### PR DESCRIPTION
- Implemented `create-draft-release.js` to create or update draft releases based on PR details.
- Added `get-merged-pr-info.js` to retrieve information from the most recently merged PR.
- Created `publish-release.js` to publish draft releases.
- Developed `update-and-publish-release.js` to update a release with the latest PR information and publish it.
- Introduced `upload-release-asset.js` to handle asset uploads to releases, including checking for existing assets.
- Updated workflows to utilize the new scripts for managing draft releases and publishing assets.

## What's Changed

# Tested
- [ ] View and Interact with Todoist buttons
  - [ ] View Story page with Todoist disabled
- [ ] Use both analyze and break down AI features
  - [ ] With proxy
  - [ ] Without proxy
- [ ] View development time for in progress stories
  - [ ] On page load
  - [ ] On SPA navigation
- [ ] View cycle time on a completed story
  - [ ] On page load
  - [ ] On SPA navigation
- [ ] Add notes to a story


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automation for creating, updating, and publishing draft GitHub releases based on pull request details.
  - Added automated uploading of release assets to GitHub releases.

- **Refactor**
  - Streamlined release workflows by moving complex logic into reusable external scripts.
  - Modularized release asset upload and release publishing steps for improved maintainability.

- **Chores**
  - Refined workflow permissions for enhanced security.
  - Simplified and clarified workflow steps and directory handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->